### PR TITLE
Add --handover option to lower partially using SFC

### DIFF
--- a/src/main/scala/circt/stage/Annotations.scala
+++ b/src/main/scala/circt/stage/Annotations.scala
@@ -90,3 +90,33 @@ case class EmittedMLIR(
   override def getBytes = value.getBytes
 
 }
+
+
+object CIRCTHandover extends HasShellOptions {
+
+  sealed trait Type
+
+  case object CHIRRTL extends Type
+  case object HighFIRRTL extends Type
+  case object MiddleFIRRTL extends Type
+  case object LowFIRRTL extends Type
+  case object LowOptimizedFIRRTL extends Type
+
+  override def options = Seq(
+    new ShellOption[String](
+      longOption = "handover",
+      toAnnotationSeq = _ match {
+        case "chirrtl" => Seq(CIRCTHandover(CHIRRTL))
+        case "high" => Seq(CIRCTHandover(HighFIRRTL))
+        case "middle" => Seq(CIRCTHandover(MiddleFIRRTL))
+        case "low" => Seq(CIRCTHandover(LowFIRRTL))
+        case "lowopt" => Seq(CIRCTHandover(LowOptimizedFIRRTL))
+        case a => throw new OptionsException(s"Unknown handover point '$a'! (Did you misspell it?)")
+      },
+      helpText = "Switch to the CIRCT compiler at this point, using the Scala FIRRTL Compiler if needed",
+      helpValueName = Some("{chirrtl|high|middle|low|lowopt}")
+    )
+  )
+}
+
+case class CIRCTHandover(handover: CIRCTHandover.Type) extends NoTargetAnnotation with CIRCTOption

--- a/src/main/scala/circt/stage/CIRCTOptions.scala
+++ b/src/main/scala/circt/stage/CIRCTOptions.scala
@@ -15,14 +15,16 @@ class CIRCTOptions private[stage](
   val inputFile: Option[File] = None,
   val outputFile: Option[File] = None,
   val disableLowerTypes: Boolean = false,
-  val target: Option[CIRCTTarget.Type] = None
+  val target: Option[CIRCTTarget.Type] = None,
+  val handover: Option[CIRCTHandover.Type] = None
 ) {
 
   private[stage] def copy(
     inputFile: Option[File] = inputFile,
     outputFile: Option[File] = outputFile,
     disableLowerTypes: Boolean = disableLowerTypes,
-    target: Option[CIRCTTarget.Type] = target
-  ): CIRCTOptions = new CIRCTOptions(inputFile, outputFile, disableLowerTypes, target)
+    target: Option[CIRCTTarget.Type] = target,
+    handover: Option[CIRCTHandover.Type] = handover
+  ): CIRCTOptions = new CIRCTOptions(inputFile, outputFile, disableLowerTypes, target, handover)
 
 }

--- a/src/main/scala/circt/stage/CIRCTStage.scala
+++ b/src/main/scala/circt/stage/CIRCTStage.scala
@@ -20,7 +20,8 @@ trait CLI { this: Shell =>
   Seq(
     CIRCTTargetAnnotation,
     DisableLowerTypes,
-    ChiselGeneratorAnnotation
+    ChiselGeneratorAnnotation,
+    CIRCTHandover
   ).foreach(_.addOptions(parser))
 }
 
@@ -32,7 +33,7 @@ trait CLI { this: Shell =>
 class CIRCTStage extends Stage {
 
   override def prerequisites = Seq.empty
-  override def optionalPrerequisites = Seq.empty
+  override def optionalPrerequisites = Seq(Dependency[firrtl.stage.phases.Compiler])
   override def optionalPrerequisiteOf = Seq.empty
   override def invalidates(a: Phase) = false
 

--- a/src/main/scala/circt/stage/package.scala
+++ b/src/main/scala/circt/stage/package.scala
@@ -35,6 +35,7 @@ package object stage {
             case OutputFileAnnotation(a)  => acc.copy(outputFile = Some(new File(a)))
             case CIRCTTargetAnnotation(a) => acc.copy(target = Some(a))
             case DisableLowerTypes        => acc.copy(disableLowerTypes = true)
+            case CIRCTHandover(a)         => acc.copy(handover = Some(a))
             case _                        => acc
           }
         }

--- a/src/main/scala/circt/stage/phases/AddDefaults.scala
+++ b/src/main/scala/circt/stage/phases/AddDefaults.scala
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package circt.stage.phases
+
+import circt.Implicits.BooleanImplicits
+import circt.stage.CIRCTHandover
+
+import firrtl.AnnotationSeq
+import firrtl.options.Phase
+
+class AddDefaults extends Phase {
+
+  override def prerequisites = Seq.empty
+  override def optionalPrerequisites = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
+  override def invalidates(a: Phase) = false
+
+  override def transform(annotations: AnnotationSeq): AnnotationSeq = {
+
+    var handover = false
+    annotations.foreach {
+      case _: CIRCTHandover => handover = true
+      case _ =>
+    }
+
+    annotations ++
+      (!handover).option(CIRCTHandover(CIRCTHandover.LowOptimizedFIRRTL))
+  }
+
+}

--- a/src/main/scala/circt/stage/phases/CIRCT.scala
+++ b/src/main/scala/circt/stage/phases/CIRCT.scala
@@ -56,7 +56,7 @@ class CIRCT extends Phase {
 
     val binary = "firtool"
 
-    val cmd = (
+    val cmd =
       Seq(binary, "-format=fir") ++
         (circtOptions.disableLowerTypes match {
            case true  => None
@@ -71,10 +71,10 @@ class CIRCT extends Phase {
              "No 'circtOptions.target' specified. This should be impossible if dependencies are satisfied!"
            )
          })
-    ) #< new java.io.ByteArrayInputStream(input.getBytes)
 
     try {
-      val result = cmd.!!
+      logger.info(s"""Running CIRCT: '${cmd.mkString(" ")} < $$input'""")
+      val result = (cmd #< new java.io.ByteArrayInputStream(input.getBytes)).!!
 
       circtOptions.target match {
         case Some(CIRCTTarget.FIRRTL) =>

--- a/src/main/scala/circt/stage/phases/MaybeSFC.scala
+++ b/src/main/scala/circt/stage/phases/MaybeSFC.scala
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package circt.stage.phases
+
+import circt.stage.{
+  CIRCTHandover,
+  CIRCTOptions
+}
+
+import firrtl.AnnotationSeq
+import firrtl.options.{
+  Dependency,
+  Phase
+}
+import firrtl.options.Viewer.view
+import firrtl.stage.{
+  Forms,
+  RunFirrtlTransformAnnotation
+}
+
+class MaybeSFC extends Phase {
+
+  override def prerequisites = Seq(Dependency[circt.stage.phases.AddDefaults])
+  override def optionalPrerequisites = Seq.empty
+  override def optionalPrerequisiteOf = Seq(Dependency[circt.stage.CIRCTStage])
+  override def invalidates(a: Phase) = false
+
+  override def transform(annotations: AnnotationSeq) = {
+    val sfcAnnotations: Option[AnnotationSeq] = view[CIRCTOptions](annotations).handover.get match {
+      case CIRCTHandover.CHIRRTL      => None
+      case CIRCTHandover.HighFIRRTL   => Some(Seq(RunFirrtlTransformAnnotation(new firrtl.HighFirrtlEmitter)))
+      case CIRCTHandover.MiddleFIRRTL => Some(Seq(RunFirrtlTransformAnnotation(new firrtl.MiddleFirrtlEmitter)))
+      case CIRCTHandover.LowFIRRTL    => Some(Seq(RunFirrtlTransformAnnotation(new firrtl.LowFirrtlEmitter)))
+      case CIRCTHandover.LowOptimizedFIRRTL =>
+        Some(
+          (Forms.LowFormOptimized.toSet -- Forms.LowFormMinimumOptimized)
+            .map(_.getObject())
+            .map(RunFirrtlTransformAnnotation.apply).toSeq :+
+            RunFirrtlTransformAnnotation(new firrtl.LowFirrtlEmitter)
+        )
+    }
+
+    sfcAnnotations match {
+      case Some(extra) =>
+        logger.info(
+          s"Running the Scala FIRRTL Compiler to CIRCT handover at ${view[CIRCTOptions](annotations).handover.get}"
+        )
+        (new firrtl.stage.phases.Compiler).transform(extra ++ annotations)
+      case None => annotations
+    }
+  }
+
+}


### PR DESCRIPTION
Add a "handover" option that augments circt.stage.ChiselStage to lower
using a combination of the Scala FIRRTL Compiler (SFC) followed by
CIRCT.  The handover can be set at CHIRRTL (don't run the SFC), High
FIRRTL, Middle FIRRTL, Low FIRRTL, or Optimized Low FIRRTL.

Include tests of this behavior by looking at the
FirrtlCircuitAnnotation that exists before running CIRCT for different
handover values.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>