### PR TITLE
Annotation Support

### DIFF
--- a/src/main/scala/circt/stage/phases/Checks.scala
+++ b/src/main/scala/circt/stage/phases/Checks.scala
@@ -18,10 +18,7 @@ import firrtl.options.{
   OptionsException,
   Phase
 }
-import firrtl.stage.{
-  RunFirrtlTransformAnnotation,
-  OutputFileAnnotation
-}
+import firrtl.stage.OutputFileAnnotation
 
 /** Check properties of an [[AnnotationSeq]] to look for errors before running CIRCT. */
 class Checks extends Phase {
@@ -32,19 +29,13 @@ class Checks extends Phase {
   override def invalidates(a: Phase) = false
 
   override def transform(annotations: AnnotationSeq): AnnotationSeq = {
-    val transforms, outputFile, target, handover = collection.mutable.ArrayBuffer[Annotation]()
+    val outputFile, target, handover = collection.mutable.ArrayBuffer[Annotation]()
 
     annotations.foreach {
-      case a @ RunFirrtlTransformAnnotation(_: Emitter) =>
-      case a: RunFirrtlTransformAnnotation => transforms += a
       case a: OutputFileAnnotation => outputFile += a
       case a: CIRCTTargetAnnotation => target += a
       case a: CIRCTHandover => handover += a
       case _ =>
-    }
-
-    if (!transforms.isEmpty) {
-      throw new OptionsException("CIRCT does not support any custom transforms")
     }
 
     if (outputFile.size != 1) {

--- a/src/main/scala/circt/stage/phases/MaybeSFC.scala
+++ b/src/main/scala/circt/stage/phases/MaybeSFC.scala
@@ -45,7 +45,12 @@ class MaybeSFC extends Phase {
         logger.info(
           s"Running the Scala FIRRTL Compiler to CIRCT handover at ${view[CIRCTOptions](annotations).handover.get}"
         )
-        (new firrtl.stage.phases.Compiler).transform(extra ++ annotations)
+        /* Do not run custom transforms in the SFC.  This messes with scheduling. */
+        val (toSFC, toMFC) = annotations.partition {
+          case _: RunFirrtlTransformAnnotation => false
+          case _ => true
+        }
+        (new firrtl.stage.phases.Compiler).transform(extra ++ toSFC) ++ toMFC
       case None => annotations
     }
   }


### PR DESCRIPTION
Add support for passing annotations on to the MFC invocation.  Convert `RunFirrtlTransformAnnotation`s that the MFC supports to command line arguments.  E.g., generate `-blackbox` or `-inline` for the MFC.