### PR TITLE
Change disableLowerTypes to preserveAggregate option

### DIFF
--- a/src/main/scala/circt/stage/Annotations.scala
+++ b/src/main/scala/circt/stage/Annotations.scala
@@ -20,15 +20,14 @@ import firrtl.stage.FirrtlOptions
 /** An option consumed by [[circt.stage.CIRCTStage CIRCTStage]]*/
 sealed trait CIRCTOption extends Unserializable { this: Annotation => }
 
-/** Turns off type lowering in CIRCT. The option `-enable-lower-types` is passed by default to CIRCT and this annotation
-  * turns that off.
+/** Preserve passive aggregate types in CIRCT.
   */
-case object DisableLowerTypes extends NoTargetAnnotation with CIRCTOption with HasShellOptions {
+case object PreserveAggregate extends NoTargetAnnotation with CIRCTOption with HasShellOptions {
 
   override def options = Seq(
     new ShellOption[Unit](
-      longOption = "disable-lower-types",
-      toAnnotationSeq = _ => Seq(DisableLowerTypes),
+      longOption = "preserve-aggregate",
+      toAnnotationSeq = _ => Seq(PreserveAggregate),
       helpText = "Do not lower aggregate types to ground types"
     )
   )

--- a/src/main/scala/circt/stage/CIRCTOptions.scala
+++ b/src/main/scala/circt/stage/CIRCTOptions.scala
@@ -8,13 +8,13 @@ import java.io.File
   *
   * @param inputFile the name of an input FIRRTL IR file
   * @param outputFile the name of the file where the result will be written
-  * @param disableLowerTypes causes CIRCT to not lower aggregate FIRRTL IR types
+  * @param preserveAggregate causes CIRCT to not lower aggregate FIRRTL IR types
   * @param target the specific IR or language target that CIRCT should compile to
  */
 class CIRCTOptions private[stage](
   val inputFile: Option[File] = None,
   val outputFile: Option[File] = None,
-  val disableLowerTypes: Boolean = false,
+  val preserveAggregate: Boolean = false,
   val target: Option[CIRCTTarget.Type] = None,
   val handover: Option[CIRCTHandover.Type] = None,
   val firtoolOptions: Seq[String] = Seq.empty
@@ -23,10 +23,10 @@ class CIRCTOptions private[stage](
   private[stage] def copy(
     inputFile: Option[File] = inputFile,
     outputFile: Option[File] = outputFile,
-    disableLowerTypes: Boolean = disableLowerTypes,
+    preserveAggregate: Boolean = preserveAggregate,
     target: Option[CIRCTTarget.Type] = target,
     handover: Option[CIRCTHandover.Type] = handover,
     firtoolOptions: Seq[String] = firtoolOptions
-  ): CIRCTOptions = new CIRCTOptions(inputFile, outputFile, disableLowerTypes, target, handover, firtoolOptions )
+  ): CIRCTOptions = new CIRCTOptions(inputFile, outputFile, preserveAggregate, target, handover, firtoolOptions )
 
 }

--- a/src/main/scala/circt/stage/CIRCTStage.scala
+++ b/src/main/scala/circt/stage/CIRCTStage.scala
@@ -19,7 +19,7 @@ trait CLI { this: Shell =>
   parser.note("CIRCT (MLIR FIRRTL Compiler) options")
   Seq(
     CIRCTTargetAnnotation,
-    DisableLowerTypes,
+    PreserveAggregate,
     ChiselGeneratorAnnotation,
     CIRCTHandover
   ).foreach(_.addOptions(parser))

--- a/src/main/scala/circt/stage/package.scala
+++ b/src/main/scala/circt/stage/package.scala
@@ -5,7 +5,7 @@ package circt
 import circt.stage.{
   CIRCTOption,
   CIRCTTargetAnnotation,
-  DisableLowerTypes
+  PreserveAggregate
 }
 
 import firrtl.AnnotationSeq
@@ -34,7 +34,7 @@ package object stage {
             case FirrtlFileAnnotation(a)  => acc.copy(inputFile = Some(new File(a)))
             case OutputFileAnnotation(a)  => acc.copy(outputFile = Some(new File(a)))
             case CIRCTTargetAnnotation(a) => acc.copy(target = Some(a))
-            case DisableLowerTypes        => acc.copy(disableLowerTypes = true)
+            case PreserveAggregate        => acc.copy(preserveAggregate = true)
             case CIRCTHandover(a)         => acc.copy(handover = Some(a))
             case FirtoolOption(a)         => acc.copy(firtoolOptions = acc.firtoolOptions :+ a)
             case _                        => acc

--- a/src/main/scala/circt/stage/phases/CIRCT.scala
+++ b/src/main/scala/circt/stage/phases/CIRCT.scala
@@ -126,7 +126,8 @@ class CIRCT extends Phase {
         circtOptions.firtoolOptions ++
         logLevel.toCIRCTOptions ++
         /* The following options are on by default, so we disable them if they are false. */
-        (circtOptions.disableLowerTypes).option("-lower-types=0") ++
+        (circtOptions.preserveAggregate).option("-preserve-aggregate=1") ++
+        (circtOptions.preserveAggregate).option("-preserve-public-types=0") ++
         (!inferReadWrite).option("-infer-rw=0") ++
         (!imcp).option("-imcp=0") ++
         /* The following options are off by default, so we enable them if they are true. */


### PR DESCRIPTION
This commit replaces `disableLowerTypes` option with `preserveAggregate` option to enable aggregate preservation mode in firtool.

I assume disableLowerTypes option was originally created 1 year ago to incubate  aggregate preservation mode we have today. 
Therefore I would assume that it should be fine to replace disableLowerTypes with preserveAggregate option.