### PR TITLE
Add support for new preserve-aggregate options

### DIFF
--- a/src/main/scala/circt/stage/Annotations.scala
+++ b/src/main/scala/circt/stage/Annotations.scala
@@ -11,19 +11,30 @@ import firrtl.stage.FirrtlOptions
 /** An option consumed by [[circt.stage.CIRCTStage CIRCTStage]] */
 sealed trait CIRCTOption extends Unserializable { this: Annotation => }
 
-/** Preserve passive aggregate types in CIRCT.
-  */
-case object PreserveAggregate extends NoTargetAnnotation with CIRCTOption with HasShellOptions {
+object PreserveAggregate extends HasShellOptions {
+  sealed trait Type
+  object OneDimVec extends Type
+  object Vec extends Type
+  object All extends Type
 
   override def options = Seq(
-    new ShellOption[Unit](
+    new ShellOption[String](
       longOption = "preserve-aggregate",
-      toAnnotationSeq = _ => Seq(PreserveAggregate),
+      toAnnotationSeq = _ match {
+        case "none"   => Seq.empty
+        case "1d-vec" => Seq(PreserveAggregate(PreserveAggregate.OneDimVec))
+        case "vec"    => Seq(PreserveAggregate(PreserveAggregate.Vec))
+        case "all"    => Seq(PreserveAggregate(PreserveAggregate.All))
+      },
       helpText = "Do not lower aggregate types to ground types"
     )
   )
 
 }
+
+/** Preserve passive aggregate types in CIRCT.
+  */
+case class PreserveAggregate(mode: PreserveAggregate.Type) extends NoTargetAnnotation with CIRCTOption
 
 /** Object storing types associated with different CIRCT target languages, e.g., RTL or SystemVerilog */
 object CIRCTTarget {

--- a/src/main/scala/circt/stage/CIRCTOptions.scala
+++ b/src/main/scala/circt/stage/CIRCTOptions.scala
@@ -14,7 +14,7 @@ import java.io.File
 class CIRCTOptions private[stage] (
   val inputFile:         Option[File] = None,
   val outputFile:        Option[File] = None,
-  val preserveAggregate: Boolean = false,
+  val preserveAggregate: Option[PreserveAggregate.Type] = None,
   val target:            Option[CIRCTTarget.Type] = None,
   val handover:          Option[CIRCTHandover.Type] = None,
   val firtoolOptions:    Seq[String] = Seq.empty) {
@@ -22,7 +22,7 @@ class CIRCTOptions private[stage] (
   private[stage] def copy(
     inputFile:         Option[File] = inputFile,
     outputFile:        Option[File] = outputFile,
-    preserveAggregate: Boolean = preserveAggregate,
+    preserveAggregate: Option[PreserveAggregate.Type] = preserveAggregate,
     target:            Option[CIRCTTarget.Type] = target,
     handover:          Option[CIRCTHandover.Type] = handover,
     firtoolOptions:    Seq[String] = firtoolOptions

--- a/src/main/scala/circt/stage/package.scala
+++ b/src/main/scala/circt/stage/package.scala
@@ -25,7 +25,7 @@ package object stage {
             case FirrtlFileAnnotation(a)  => acc.copy(inputFile = Some(new File(a)))
             case OutputFileAnnotation(a)  => acc.copy(outputFile = Some(new File(a)))
             case CIRCTTargetAnnotation(a) => acc.copy(target = Some(a))
-            case PreserveAggregate        => acc.copy(preserveAggregate = true)
+            case PreserveAggregate(a)     => acc.copy(preserveAggregate = Some(a))
             case CIRCTHandover(a)         => acc.copy(handover = Some(a))
             case FirtoolOption(a)         => acc.copy(firtoolOptions = acc.firtoolOptions :+ a)
             case _                        => acc

--- a/src/main/scala/circt/stage/phases/CIRCT.scala
+++ b/src/main/scala/circt/stage/phases/CIRCT.scala
@@ -3,7 +3,7 @@
 package circt.stage.phases
 
 import circt.Implicits.BooleanImplicits
-import circt.stage.{CIRCTOptions, CIRCTTarget, EmittedMLIR}
+import circt.stage.{CIRCTOptions, CIRCTTarget, EmittedMLIR, PreserveAggregate}
 
 import firrtl.{AnnotationSeq, EmittedVerilogCircuit, EmittedVerilogCircuitAnnotation}
 import firrtl.options.{
@@ -116,8 +116,13 @@ class CIRCT extends Phase {
         circtOptions.firtoolOptions ++
         logLevel.toCIRCTOptions ++
         /* The following options are on by default, so we disable them if they are false. */
-        (circtOptions.preserveAggregate).option("-preserve-aggregate=1") ++
-        (circtOptions.preserveAggregate).option("-preserve-public-types=0") ++
+        (circtOptions.preserveAggregate match {
+          case Some(PreserveAggregate.OneDimVec) => Seq("-preserve-aggregate=1d-vec")
+          case Some(PreserveAggregate.Vec)       => Seq("-preserve-aggregate=vec")
+          case Some(PreserveAggregate.All)       => Seq("-preserve-aggregate=all")
+          case None                              => None
+        }) ++
+        circtOptions.preserveAggregate.map(_ => "-preserve-public-types=0") ++
         (!inferReadWrite).option("-infer-rw=0") ++
         (!imcp).option("-imcp=0") ++
         /* The following options are off by default, so we enable them if they are true. */

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -159,7 +159,10 @@ class ChiselStageSpec extends AnyFunSpec with Matchers {
 
       info(s"output contains a verilog struct using preserve-aggregate option")
       (new ChiselStage)
-        .execute(args, Seq(ChiselGeneratorAnnotation(() => new ChiselStageSpec.Baz), PreserveAggregate))
+        .execute(
+          args,
+          Seq(ChiselGeneratorAnnotation(() => new ChiselStageSpec.Baz), PreserveAggregate(PreserveAggregate.All))
+        )
         .collectFirst {
           case EmittedVerilogCircuitAnnotation(a) => a
         }


### PR DESCRIPTION
Add support for the new, finer-grained aggregate preservation options
that were added to CIRCT/firtool.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>