### PR TITLE
Change CI to use published CIRCT binary

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -10,15 +10,18 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/circt/images/circt:nightly
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         scala: [2.12.15, 2.13.6]
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v10
+      - name: Install CIRCT
+        run: |
+          mkdir usr
+          wget https://github.com/llvm/circt/releases/download/sifive%2F1%2F11%2F0/circt-bin-ubuntu-20.04.tar.gz -O - | tar -zx -C usr/
+          echo "$(pwd)/usr/bin" >> $GITHUB_PATH
       - name: Setup and run tests
         run: sbt ++${{ matrix.scala }} test
       - name: Check Formatting (Scala 2.12 only)
@@ -27,7 +30,7 @@ jobs:
 
   publish:
     needs: [test]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v2.3.4


### PR DESCRIPTION
Change GitHub CI to use a tagged, published Ubuntu binary of CIRCT
instead of relying on a nightly docker image.  This is both: (1) more
stable and (2) way faster.  This also removes a barrier to upstreaming
chisel-circt with chisel3.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>