### PR TITLE
Enable Trace API

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,6 +1,6 @@
 name: Scala CI
 env:
-  CIRCT_VERSION: sifive/1/19/0
+  CIRCT_VERSION: sifive/1/20/0
 
 on:
   workflow_dispatch:

--- a/build.sbt
+++ b/build.sbt
@@ -22,5 +22,7 @@ lazy val root = (project in file("."))
     name := "chisel-circt",
     libraryDependencies += scalaTest % Test,
     libraryDependencies += chisel3,
-    addCompilerPlugin(chiselCompilerPlugin cross CrossVersion.full)
+    addCompilerPlugin(chiselCompilerPlugin cross CrossVersion.full),
+    resolvers +=
+      "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.7"
-  private val chiselVersion = "3.5.4"
+  private val chiselVersion = "3.5-SNAPSHOT"
   lazy val chisel3 = "edu.berkeley.cs" %% "chisel3" % chiselVersion
   lazy val chiselCompilerPlugin = "edu.berkeley.cs" %% "chisel3-plugin" % chiselVersion
 }


### PR DESCRIPTION
Update the CIRCT phase to support Chisel's Trace API.  This is an API that allows a user to add a TraceNameAnnotation that will be updated and output by a FIRRTL compiler.  The intent of this API is that it gives a user the ability to find the final FIRRTL Target for the original annotated component.  This is intentionally a low-level API that enables building more complex APIs, e.g., TCL emission, without requiring custom pass injection into the FIRRTL compiler.

This requires a few modifications to internal to find/load an output annotation file from CIRCT.  This uses a new "-output-annotation-file" option to CIRCT specific to this API.  When in "-split-verilog" output mode, the output annotation is found and read.  When in single file output mode, the output single-file string is parsed to extract the annotation section.

This patch requires using a version of CIRCT that includes changes from https://github.com/llvm/circt/pull/4065.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>