### PR TITLE
Pass NoDedupAnnotations through and get rid of -dedup flag setting

### DIFF
--- a/src/main/scala/circt/stage/phases/CIRCT.scala
+++ b/src/main/scala/circt/stage/phases/CIRCT.scala
@@ -86,7 +86,7 @@ class CIRCT extends Phase {
     val stageOptions = view[StageOptions](annotations)
 
     var blackbox, inferReadWrite = false
-    var dedup, imcp = true
+    var imcp = true
     var logLevel = _root_.logger.LogLevel.None
     var split = false
 
@@ -115,9 +115,6 @@ class CIRCT extends Phase {
         }
       case firrtl.passes.memlib.InferReadWriteAnnotation =>
         inferReadWrite = true
-        Nil
-      case _: firrtl.transforms.NoDedupAnnotation =>
-        dedup = false
         Nil
       case firrtl.transforms.NoConstantPropagationAnnotation =>
         imcp = false
@@ -163,7 +160,6 @@ class CIRCT extends Phase {
         (!inferReadWrite).option("-disable-infer-rw") ++
         (!imcp).option("-disable-imcp") ++
         /* The following options are off by default, so we enable them if they are true. */
-        (dedup).option("-dedup") ++
         (blackbox).option("-blackbox-memory") ++
         /* Communicate the annotation file through a file. */
         (chiselAnnotationFilename.map(a => Seq("-annotation-file", a))).getOrElse(Seq.empty) ++

--- a/src/main/scala/circt/stage/phases/CIRCT.scala
+++ b/src/main/scala/circt/stage/phases/CIRCT.scala
@@ -145,7 +145,7 @@ class CIRCT extends Phase {
     val binary = "firtool"
 
     val cmd =
-      Seq(binary, "-format=fir", "-warn-on-unprocessed-annotations", "-verify-each=false") ++
+      Seq(binary, "-format=fir", "-warn-on-unprocessed-annotations", "-verify-each=false", "-dedup") ++
         Seq("-output-annotation-file", circtAnnotationFilename) ++
         circtOptions.firtoolOptions ++
         logLevel.toCIRCTOptions ++


### PR DESCRIPTION
CIRCT can honor NoDedupAnnotations and in fact requires them for correctness in some cases. chisel-circt was currently stripping them out, limiting some of its usefulness. Also the `-dedup` flag is not something that should be turned off other than per-module with the annotation.